### PR TITLE
File Discovery for Maven, Nuget and Node

### DIFF
--- a/ts_scan/pm/maven/__init__.py
+++ b/ts_scan/pm/maven/__init__.py
@@ -104,7 +104,10 @@ class MavenScan(DependencyScan):
     
 
 def _find_local_repository() -> Path:
-    result = subprocess.run(["mvn", "help:evaluate", "-Dexpression=settings.localRepository", "-q", "-DforceStdout=true"], stdout=subprocess.PIPE)
+    result = subprocess.run(["mvn", "help:evaluate", "-Dexpression=settings.localRepository", "-q", "-DforceStdout=true"], 
+        stdout=subprocess.PIPE,
+        shell=True
+    )
 
     return Path(result.stdout.decode("utf-8"))
 

--- a/ts_scan/pm/maven/__init__.py
+++ b/ts_scan/pm/maven/__init__.py
@@ -90,7 +90,7 @@ class MavenScan(DependencyScan):
             dep.description = description
             dep.licenses = licenses
 
-            dep.files.append(path)
+            dep.files.extend(glob(str(path) + "\\**", recursive=True))
 
         except:
             pass

--- a/ts_scan/pm/maven/__init__.py
+++ b/ts_scan/pm/maven/__init__.py
@@ -90,7 +90,9 @@ class MavenScan(DependencyScan):
             dep.description = description
             dep.licenses = licenses
 
-            dep.files.extend(glob(str(path) + "\\**", recursive=True))
+            dep_files = glob(str(path) + "\\**", recursive=True)
+            dep_files = [p for p in dep_files if Path(p).is_file()]
+            dep.files.extend(dep_files)
 
         except:
             pass

--- a/ts_scan/pm/maven/__main__.py
+++ b/ts_scan/pm/maven/__main__.py
@@ -1,0 +1,6 @@
+from . import scan
+
+if __name__ == "__main__":
+    s = scan("C:\\Users\\Soren\\eacg\\samples\\ts-mvn-plugin")
+
+    print([dep.files for dep in s.dependencies])

--- a/ts_scan/pm/node.py
+++ b/ts_scan/pm/node.py
@@ -3,6 +3,7 @@ import json
 import requests
 from semantic_version import Version, NpmSpec
 
+from glob import glob
 from pathlib import Path
 from typing import Iterable, Optional, List
 
@@ -28,6 +29,7 @@ class NodeScan(DependencyScan):
         self.__module_id = None
         self.__failed_requests = 0
         self.__lockfile_content = None
+        self.__abs_module_path = Path(os.path.abspath(path))
         
         self.__dependencies = []
 
@@ -85,6 +87,12 @@ class NodeScan(DependencyScan):
 
         dep = Dependency("npm:" + name, name)
         dep.versions.append(version)
+
+        dep_dir = self.__abs_module_path / package_path
+        dep_files = glob(str(dep_dir) + "\\**", recursive=True)
+        dep_files = [p for p in dep_files if Path(p).is_file()]
+
+        dep.files.extend(dep_files)
 
         if name + version not in self.__processed_deps:
             self.__processed_deps.add(name + version)
@@ -159,3 +167,6 @@ if __name__ == "__main__":
     #test_scan = NodeScan("/home/soren/eacg/sample_projects/node/sample-node-project")
     test_scan = NodeScan("C:\\Users\\Soren\\eacg\\samples\\sample-node-project")
     test_scan.execute()
+
+    for dep in test_scan.dependencies:
+        print(dep.files)

--- a/ts_scan/pm/node.py
+++ b/ts_scan/pm/node.py
@@ -87,6 +87,7 @@ class NodeScan(DependencyScan):
         dep.versions.append(version)
 
         if name + version not in self.__processed_deps:
+            self.__processed_deps.add(name + version)
             print(f"Getting metadata for {name} {version}...", end="", flush=True)
 
             meta = self._metadata_from_registry(name, version)
@@ -155,5 +156,6 @@ class NodeScan(DependencyScan):
 
 if __name__ == "__main__":
     #test_scan = NodeScan("/home/soren/eacg/sample_projects/node/ts-node-client")
-    test_scan = NodeScan("/home/soren/eacg/sample_projects/node/sample-node-project")
+    #test_scan = NodeScan("/home/soren/eacg/sample_projects/node/sample-node-project")
+    test_scan = NodeScan("C:\\Users\\Soren\\eacg\\samples\\sample-node-project")
     test_scan.execute()

--- a/ts_scan/pm/nuget.py
+++ b/ts_scan/pm/nuget.py
@@ -174,10 +174,14 @@ class NugetScan(DependencyScan):
                         self.__processed_deps.add(dep_id)
 
                         if candidates:
-                            dep.files.append(candidates[0])
+                            dep_dir = candidates[0]
 
+                            dep_files = glob(str(dep_dir) + "/**", recursive=True)
+                            dep_files = [p for p in dep_files if Path(p).is_file()]
+                            dep.files.extend(dep_files)
+                            
                             # recursively create dependencies of dependency
-                            dep.dependencies = self._process_package(Path(dep.files[0]), depth=depth+1)
+                            dep.dependencies = self._process_package(Path(dep_dir), depth=depth+1)
                         
                         else:
                             self.__n_fail += 1
@@ -215,10 +219,13 @@ class NugetScan(DependencyScan):
                     dep.meta["dependency type"] = "direct"
 
                     if candidates := self._find_in_global_packages(name, version):
-                        dep_files = candidates[0]
-                        dep.files.append(dep_files)
+                        dep_dir = candidates[0]
+                        
+                        dep_files = glob(str(dep_dir) + "\\**", recursive = True)
+                        dep_files = [p for p in dep_files if Path(p).is_file()]
+                        dep.files.extend(dep_files)
 
-                        dep_nuspec = glob(str(dep_files / "*.nuspec"))[0]
+                        dep_nuspec = glob(str(dep_dir / "*.nuspec"))[0]
                         meta = self._metadata_from_nuspec(dep_nuspec)
 
                         dep.licenses.append(License("", meta["licenseUrl"]))
@@ -226,7 +233,7 @@ class NugetScan(DependencyScan):
                         dep.description = meta["description"]
                         dep.meta["copyright"] = meta["copyright"]
 
-                        dep.dependencies = self._process_package(dep_files, depth=depth+1)
+                        dep.dependencies = self._process_package(dep_dir, depth=depth+1)
 
                 deps.append(dep)
 
@@ -283,5 +290,10 @@ if __name__ == "__main__":
     #test_scan = NugetScan("/home/soren/eacg/sample_projects/nuget/AutoMapper/src/AutoMapper")
     #test_scan = NugetScan("/home/soren/eacg/sample_projects/nuget/AutoMapper")
     #test_scan = NugetScan("/home/soren/eacg/sample_projects/nuget/ts-dotnet/TrustSource/TS-NET-Scanner.Common/")
-    test_scan = NugetScan("/home/soren/eacg/sample_projects/nuget/Castleproject.Core")
+    #test_scan = NugetScan("/home/soren/eacg/sample_projects/nuget/Castleproject.Core")
+    test_scan = NugetScan("C:\\Users\\Soren\\eacg\\samples\\ts-dotnet\\TrustSource")
     test_scan.execute()
+
+    for dep in test_scan.dependencies:
+        print(dep.name)
+        print(dep.files)


### PR DESCRIPTION
These scanners now populate the `Dependency.files` list with the files the scanner can find. 